### PR TITLE
Only deploy from humans

### DIFF
--- a/.github/workflows/riffraff.yml
+++ b/.github/workflows/riffraff.yml
@@ -10,6 +10,15 @@ jobs:
     # This job runs on Linux
     runs-on: ubuntu-latest
     steps:
+      - name: Update commit status (success)
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: 'RiffRaff Trigger'
+          description: ${{ github.event.client_payload.build }}
+          state: 'pending'
+          target_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          sha: ${{ github.event.client_payload.ref }}
       - name: Clone Repository (Latest)
         uses: actions/checkout@v2
         with:
@@ -28,7 +37,7 @@ jobs:
         uses: Sibz/github-status-action@v1
         with:
           authToken: ${{secrets.GITHUB_TOKEN}}
-          context: 'RiffRaff Deploy'
+          context: 'RiffRaff Trigger'
           description: ${{ github.event.client_payload.build }}
           state: 'success'
           target_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -38,7 +47,7 @@ jobs:
         uses: Sibz/github-status-action@v1
         with:
           authToken: ${{secrets.GITHUB_TOKEN}}
-          context: 'RiffRaff Deploy'
+          context: 'RiffRaff Trigger'
           description: ${{ github.event.client_payload.build }}
           state: 'failure'
           target_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,14 @@ Right now, you need to do 3 things to set this up:
 
 RiffRaff payload: 
 ```json
-{"vcsUrl": "%deploy.tag.vcsUrl%", "vcsRevision": "%deploy.tag.vcsRevision%", "vcsRepo": "%deploy.tag.vcsRepo%", "branch": "%deploy.tag.branch%", "build": "%deploy.build%" }
+{
+  "vcsUrl": "%deploy.tag.vcsUrl%",
+  "vcsRevision": "%deploy.tag.vcsRevision%",
+  "vcsRepo": "%deploy.tag.vcsRepo%",
+  "branch": "%deploy.tag.branch%",
+  "build": "%deploy.build%",
+  "deployer": "%deploy.deployer%"
+}
 ```
 
 2. Set up a GitHub workflow in your repo (`$REPO_ROOT_DIR/.github/workflows`) with the following template:

--- a/README.md
+++ b/README.md
@@ -33,27 +33,38 @@ jobs:
     name: <NAME>
     runs-on: <RUNS_ON>
     steps:
+    - name: Update commit status (success)
+      uses: Sibz/github-status-action@v1
+      with:
+        authToken: ${{secrets.GITHUB_TOKEN}}
+        context: 'RiffRaff Trigger'
+        description: ${{ github.event.client_payload.build }}
+        state: 'pending'
+        target_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        sha: ${{ github.event.client_payload.ref }}
+    
       ... # YOUR JOBS HERE
-      - name: Update commit status (SUCCESS)
-        if: ${{ success() }}
-        uses: Sibz/github-status-action@v1
-        with:
-          authToken: ${{secrets.GITHUB_TOKEN}}
-          context: 'RiffRaff Deploy'
-          description: ${{ github.event.client_payload.build }}
-          state: 'success'
-          target_url: "https://github.com/guardian/<REPO>/actions"
-          sha: ${{ github.event.client_payload.ref }}
-      - name: Update commit status (FAILURE)
-        if: ${{ failure() }}
-        uses: Sibz/github-status-action@v1
-        with:
-          authToken: ${{secrets.GITHUB_TOKEN}}
-          context: 'RiffRaff Deploy'
-          description: ${{ github.event.client_payload.build }}
-          state: 'failure'
-          target_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          sha: ${{ github.event.client_payload.ref }}
+
+    - name: Update commit status (SUCCESS)
+      if: ${{ success() }}
+      uses: Sibz/github-status-action@v1
+      with:
+        authToken: ${{secrets.GITHUB_TOKEN}}
+        context: 'RiffRaff Trigger'
+        description: ${{ github.event.client_payload.build }}
+        state: 'success'
+        target_url: "https://github.com/guardian/<REPO>/actions"
+        sha: ${{ github.event.client_payload.ref }}
+    - name: Update commit status (FAILURE)
+      if: ${{ failure() }}
+      uses: Sibz/github-status-action@v1
+      with:
+        authToken: ${{secrets.GITHUB_TOKEN}}
+        context: 'RiffRaff Trigger'
+        description: ${{ github.event.client_payload.build }}
+        state: 'failure'
+        target_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        sha: ${{ github.event.client_payload.ref }}
 ```
 
 3. Add a secret to your repo called `GITHUB_TOKEN`. This will be used in the Workflow to grant permissions to update a commit status.


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This ensures that deploys from non-humans (continuous or scheduled deployments) don't trigger a github action run, as we don't care about them.

## How to test

Deploy this branch to CODE yourself and see it trigger an action. Observe how a continuous or scheduled deploy doesn't trigger an action.
